### PR TITLE
New higher frequency measurement resolution, new 1Hz range, new averaged measurement method

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,7 @@ setAmplitude				KEYWORD2
 measurePeakVoltage			KEYWORD2
 measureCurrentVoltage		KEYWORD2
 measureFrequency			KEYWORD2
+measureAverageFrequency			KEYWORD2
 measurePhase				KEYWORD2
 setOffset					KEYWORD2
 enableSignOutput			KEYWORD2

--- a/src/tsunami.h
+++ b/src/tsunami.h
@@ -165,13 +165,19 @@ public:
   }
 
   /* Measures frequency, returning a value in Hz.
-   * This works from approximately 32Hz upwards.
+   * This works from approximately 1.0Hz upwards.
    *
    * Return values are accurate, but will suffer some jitter due to the analog
    * nature of the input signal. Measuring the square wave output will give a more
    * precise result than measuring the sine wave output.
    */
   float measureFrequency();
+  
+  /* Same as above, but with a moving average ratio of "1/8 new data" applied.
+   * Ordinarily it tracks to the instant value rather quickly but whenever the
+   * divided signal is a really low frequency the reaction time is observable.
+   */
+  float measureAverageFrequency();
 
   /* Measures phase offset, returning a figure between 0 and 1. 0 indicates the
    * signals are 180 degrees out of phase, while 1 indicates the signals are


### PR DESCRIPTION
This is just to let you know I've pushed my changes to my fork, you're welcome to take a look. There are essentially two differences: 
- I use a prescaler of 1:1 instead of 1:8 and I'm also implementing a "top word" timer1 overflow counter using the timer pretty much exclusively in overflow mode - more bits, more resolution. As an (intentional) side effect, this method can go down all the way to 1Hz (and below, but I've limited it at 1Hz - well, 0.9Hz to be precise, so we can "see" the ~0.95 Hz that Tsunami generates for a "1 Hz" command) since the overflow at ~31Hz is no longer an issue. I've also set an arbitrary high limit of 3.2MHz, above which the electronics seem to go wobbly and measure random nonsense (hence the limit).
- I implemented a moving average filtering on the frequency measurement and exposed it as a secondary method called "measureAverageFrequency" - the original is still returning the instant value; it implements a "new value = 7/8 old value + 1/8 new measurement" filter and it tends to help a lot smoothing down lower digit jitter (when the instant value is jittery). It is digit-precise coming from both directions (as in 250000.00 really reads exactly 250000.00 if that's measured - normally an issue since these filters are asymptotic in nature and not exact when integer values are involved, but that has been worked around here) and it converges on new values quite quickly but not instantly - but this way the user is free to choose which measurement suits him best.

Finally, just for lulz I'm attaching the graphs I've used for study, illustrating the performance difference (they're log/log - resolution against frequency - and calculated for each binary order of magnitude from your 1024 lower limit (top) up to 65536 (bottom); they just happened to turn out straight lines in log-log space); this one shows all possible combinations on 4 input divider values and 5 prescaler settings (some of them overlap identically, hence the dashed lines):

![tsunami resolution - all divisions](https://cloud.githubusercontent.com/assets/2522619/10467798/6b8a7244-7204-11e5-95b7-8197ba249222.png)

...while this one illustrates the resolutions of the traditional divisors vs. the new ones (the new ones all being extensions of their base ranges due to being used in overflow mode); the result is precision boost of about one to two orders of magnitude, depending on which hysteresis path compares to which one:

![tsunami resolution - old and new divisions](https://cloud.githubusercontent.com/assets/2522619/10467808/78f90a80-7204-11e5-9893-01ea1490679a.png)

...it ends up being about 61Hz at 2MHz which I reckon is not bad. Counting could improve it a little more, but unless one wants a 1FPS update rate counting for full seconds, the difference doesn't seem huge, so I didn't bother. Anyway, I also have that data in LibreOffice Calc if you're interested but I couldn't figure out how to attach it here in a meaningful way.
