### PR TITLE
Added missing mean voltage measurement method and some ADC scaling corrections

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,6 +7,7 @@ selectFrequency				KEYWORD2
 selectPhase					KEYWORD2
 setAmplitude				KEYWORD2
 measurePeakVoltage			KEYWORD2
+measureMeanVoltage			KEYWORD2
 measureCurrentVoltage		KEYWORD2
 measureFrequency			KEYWORD2
 measureAverageFrequency			KEYWORD2

--- a/src/tsunami.cpp
+++ b/src/tsunami.cpp
@@ -197,7 +197,7 @@ void Tsunami_Class::begin() {
   mcp49xx_write(&dac, TSUNAMI_OFFSET_ID, 2048);
 
   // Configure ADC to use internal 2.56V reference
-  analogReference(INTERNAL);
+  setAnalogRef(INTERNAL);
 
 	current_frequency_reg = 0;
   current_phase_reg = 0;


### PR DESCRIPTION
You might be interested in a few things I fixed:
- There was no method to read the "average" (offset) of the measured input signal, I added one.
- Fixed the output offset constant "TSUNAMI_OFFSET_FS": 3731 was probably meant for a version where the R13/R15 reference voltage divisor was 5V-supplied and R14 was 402 ohms; now the divisor is 3.3V-supplied though and R14 seems to be something like 243 ohms (sort of hard to tell without an up-to-date schematic), which leads to Vref = 3.3 \* 1/(10+1) = 0.3V therefore scaling becomes 0.3 \* 3300 / 243 = 4.074V = 4074mv which is a good bit away from 3731. Unfortunately, that's still nowhere near correct because additional current (likely from the two current-guzzling opamp inputs - tens of microamps over a one kilo resistor become tens of millivolts) adds some additional voltage drop, making the reference actually around 0.31V - but since I'm unable to specify the leak precisely I didn't correct for it in the proposed new value; perhaps calibration can take care of that later on.
- Fixed the input average / offset measurement constant "TSUNAMI_VIN_RANGE": not sure what 3300 was for, but based on the values of R2, R4 and R6 the resulting voltage follows the law Vdiv  = (Vin + 3.023622) / 2.372724, which yields an input swing of -3.023622V ... +3.050552V corresponding to the 0V ... 2.56V range the ADC is currently set up to cover. That's an 6.074V input range so I set the constant to half that, 3037mV.
- Fixed the phase measurement by temporarily switching back to the Vcc reference for the duration ofthe phase measurement, considering one cannot convert the incoming full 0V ... Vcc range with a 2.56V reference (this is partly what causes the current phase measurement issues - some problems in the hardware remain though, it seems to me that at the input of the "freqin" opamp we have way too much additional phase shift; maybe messing with R1 or R3 could help some more?)
- Finally, the change from "analogReference" to "setAnalogRef" is there to avoid the first few measurements going badly wrong: it seems that measuring anything right after an ADC reference switch doesn't give time the Vref capacitor to reach the new Vref value so the measured values are meaningless. Unfortunately, waiting any amount before the first measurement does nothing because "analogReference" doesn't actually switch anything, it just stores the selected Vref option which gets applied by "analogRead" immediately before a conversion starts. This spoils the first few measurements while the Vref pin cap is charging. Using the custom "setAnalogRef" gets around that because the reference gets actually switched immediately followed by a suitable delay before the function returns.

Now, regarding phase shifts - this is what I saw at 1 MHz:

Reference sign output on AUX against the input signal (loopback BNC cable from the output):
![pic_1](https://cloud.githubusercontent.com/assets/2522619/10835178/8edd9766-7ea8-11e5-8c08-f1c58ded5d03.gif)

Same at the input side of R6 ("NET_31"):
![pic_2](https://cloud.githubusercontent.com/assets/2522619/10835179/8ee20a12-7ea8-11e5-9a1f-f0a987f092e1.gif)

Same at the "divisor" side of R6 ("VIN_A4"):
![pic_3](https://cloud.githubusercontent.com/assets/2522619/10835180/8ee39242-7ea8-11e5-991d-eb7e4430e18a.gif)

Same at pin 3 of the MCP opamp (after R1):
![pic_4](https://cloud.githubusercontent.com/assets/2522619/10835181/8ee72e34-7ea8-11e5-97e8-b9ba4872438a.gif)

The resulting FREQIN signal:
![pic_5](https://cloud.githubusercontent.com/assets/2522619/10835182/8ee7af9e-7ea8-11e5-9339-0941e31951d0.gif)

The resulting phase PWM signal at the greenpak output:
![pic_6](https://cloud.githubusercontent.com/assets/2522619/10835177/8edc1f58-7ea8-11e5-82da-55385e1c013c.gif)

As much as some phase shift is unavoidable, it seems to me that bit just past R1 doesn't have to be there - wouldn't reducing R1 or eliminating R3 help? I'm not particularly good with opamps, it's an honest question...
